### PR TITLE
26 improvement return thrown weapons to weapon slot when picked up

### DIFF
--- a/src/RogueLike/Main/Creature.java
+++ b/src/RogueLike/Main/Creature.java
@@ -2660,6 +2660,16 @@ public class Creature implements Cloneable{
 			}
 			inventory.add(item);
 			stackItems();
+			if (item.isThrownWeapon()){
+				if (item.getWasCreatureWepon() && this.weapon() == null) {
+					doAction("wield a "+nameOf(item));
+					weapon = item;
+					weaponName = item.name();
+				}
+				else {
+					item.setWasCreatureWepon(false);
+				}
+			}
 			if(item.isInQuickslot1() || item.isInQuickslot2() || item.isInQuickslot3() || item.isInQuickslot4() || item.isInQuickslot5() || item.isInQuickslot6()) {
 				if(item.isInQuickslot1()) {
 					if(quickslot_1 == null) {

--- a/src/RogueLike/Main/Creature.java
+++ b/src/RogueLike/Main/Creature.java
@@ -2807,6 +2807,7 @@ public class Creature implements Cloneable{
 						doAction("wield a "+nameOf(item));
 						weapon = item;
 						weaponName = item.name();
+						item.setWasCreatureWepon(true);
 					}
 
 				}

--- a/src/RogueLike/Main/Factories/ObjectFactory.java
+++ b/src/RogueLike/Main/Factories/ObjectFactory.java
@@ -426,7 +426,6 @@ public class ObjectFactory {
 			player.learnNameQuiet(startItemRogue);
 			player.inventory().add(startItemRogue);
 			
-			
 			player.setHPScaleAmount(player.hpScaleMedium());
 			player.setManaScaleAmount(player.manaScaleMedium());
 			
@@ -465,6 +464,7 @@ public class ObjectFactory {
 		player.inventory().add(newScrollOfMagicMapping(0, player, false));
 		player.inventory().add(newScrollOfMagicMapping(0, player, false));
 		player.inventory().add(newScrollOfMagicMapping(0, player, false));
+		
 		//temp
 		//
 		//player.inventory().add(newScrollOfMagicMapping(0, player, false));

--- a/src/RogueLike/Main/Items/BasicThrownWeapon.java
+++ b/src/RogueLike/Main/Items/BasicThrownWeapon.java
@@ -11,5 +11,4 @@ public class BasicThrownWeapon extends BasicMeleeWeapon{
 		this.setIsThrownWeapon(true);
 		this.setThrownDamageDice(thrownDice);
 	}
-
 }

--- a/src/RogueLike/Main/Items/Item.java
+++ b/src/RogueLike/Main/Items/Item.java
@@ -234,6 +234,17 @@ public class Item implements Cloneable{
 		thrownDamageDice = dice;
 	}
 	
+	
+	// Roland code in the works
+	private boolean wasCreatureWepon = false;
+	public void setWasCreatureWepon(boolean weponState){
+		this.wasCreatureWepon = weponState;
+	}
+	public boolean getWasCreatureWepon(){
+		return wasCreatureWepon;
+	}
+	
+	
 	private Dice rangedDamageDice;
 	public Dice rangedDamageDice() {
 		return rangedDamageDice;
@@ -1238,5 +1249,7 @@ public class Item implements Cloneable{
 			throw new InternalError(e.toString());
 		}
 	}
-
+	
+	
+	
 }

--- a/src/RogueLike/Main/Items/Item.java
+++ b/src/RogueLike/Main/Items/Item.java
@@ -238,7 +238,7 @@ public class Item implements Cloneable{
 	// Roland code in the works
 	private boolean wasCreatureWepon = false;
 	public void setWasCreatureWepon(boolean weponState){
-		this.wasCreatureWepon = weponState;
+		wasCreatureWepon = weponState;
 	}
 	public boolean getWasCreatureWepon(){
 		return wasCreatureWepon;


### PR DESCRIPTION
Wepons with the thrown property will now be auto equiped if wepon slot is empty when you pick up a wepon someone threw (applies to monsters too, if monster that throws cursed wepons exist then we need to look into this one again.)