### PR TITLE
Gremlins no longer immediately kill the player on entering depth 5

### DIFF
--- a/src/RogueLike/Main/AI/CreatureAI.java
+++ b/src/RogueLike/Main/AI/CreatureAI.java
@@ -97,9 +97,8 @@ public class CreatureAI {
 		this.itemNames = new HashMap<String, String>();
 		this.factory = factory;
 		this.world = world;
-		actionQueue.add(1);
 		actionQueue.add(1000);
-		
+		actionQueue.add(1000);
 	}
 	
 	public String getName(Item item) {

--- a/src/RogueLike/Main/World.java
+++ b/src/RogueLike/Main/World.java
@@ -486,12 +486,13 @@ public class World {
 	}
 	
 	public void updateOnCurrentFloor(Creature player) {
-		turnNumber ++;
-		List<Creature> toUpdate = new ArrayList<Creature>(creatures);
-		if(player.ai().actionQueue().isEmpty() == true) {
-			//player.ai().playerAIMoveIdle();
+		if(player.ai().actionQueue().isEmpty()) {
+			// the player isn't doing anything - don't update
 			return;
 		}
+		List<Creature> toUpdate = new ArrayList<Creature>(creatures);
+		turnNumber++;
+		System.out.printf(" ----- [TURN %d] ----- %n", turnNumber);
 		Collections.sort(toUpdate, Comparator.comparing(Creature::getActionSpeed));
 	    for (Creature creature : toUpdate){
 	    	if(creature.z() == player.z()) {


### PR DESCRIPTION
Previously, as soon as the player entered depth 5, they would immediately be pincushioned by a large number of Gremlins, as every Gremlin on the floor would shoot the player at once on the first turn they stepped onto the floor regardless of range or distance. This is now fixed!