### PR TITLE
Add ignore file to exclude formatting commits from history

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Run this command to always ignore the listed formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Formatting entire codebase with google-java-format
+5cfd7d16c9a37a4005a6a76b5604668e6f4a9c86


### PR DESCRIPTION
Run the below command (in this branch, or once this PR is merged) to ignore formatting commits in your Git blames:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

This should also cause GitHub to exclude these files from its blames by default.